### PR TITLE
fix: add workaround for a Safari IME bug

### DIFF
--- a/.changeset/loud-onions-guess.md
+++ b/.changeset/loud-onions-guess.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-flat-list': patch
+---
+
+Add a workaround for a Safari bug, which causes the list node to be removed when input inside an empty list node with IME.

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -5,9 +5,10 @@
     margin-bottom: 0;
     margin-left: 32px;
     margin-bottom: 0;
-    position: relative;
     display: list-item;
     list-style: none;
+
+    /* Note: we cannot add "position: relative;" here because of a Safari bug: https://github.com/ocavue/prosemirror-flat-list/issues/50 */
   }
 
   &.ProseMirror-selectednode {
@@ -37,7 +38,7 @@
     }
     &::before {
       position: absolute;
-      right: 100%;
+      transform: translateX(-100%);
       font-variant-numeric: tabular-nums;
       content: counter(prosemirror-flat-list-counter, decimal) '. ';
     }
@@ -46,7 +47,7 @@
   &[data-list-kind='task'] {
     & > .list-marker {
       position: absolute;
-      right: 100%;
+      transform: translateX(-100%);
       text-align: center;
       width: 1.5em;
       width: 1lh;
@@ -61,7 +62,7 @@
   &[data-list-kind='toggle'] {
     & > .list-marker {
       position: absolute;
-      right: 100%;
+      transform: translateX(-100%);
       text-align: center;
       width: 1.5em;
       width: 1lh;


### PR DESCRIPTION
Closes https://github.com/ocavue/prosemirror-flat-list/issues/50


https://user-images.githubusercontent.com/24715727/221367048-9aa91ed1-8f73-4224-b7e8-b3cf3d803107.mp4

