### PR TITLE
fix: add a plugin as Safari IME bug workaround

### DIFF
--- a/.changeset/brave-mugs-allow.md
+++ b/.changeset/brave-mugs-allow.md
@@ -1,0 +1,6 @@
+---
+'remirror-extension-flat-list': patch
+'prosemirror-flat-list': patch
+---
+
+Add a new plugin `createSafariInputMethodWorkaroundPlugin` as another workaround for the [Safari IME bug](https://github.com/ProseMirror/prosemirror/issues/934)

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -1,0 +1,12 @@
+// Copied from https://github.com/prosemirror/prosemirror-view/blob/1.30.1/src/browser.ts
+
+const nav = typeof navigator != 'undefined' ? navigator : null
+const agent = (nav && nav.userAgent) || ''
+
+const ie_edge = /Edge\/(\d+)/.exec(agent)
+const ie_upto10 = /MSIE \d/.exec(agent)
+const ie_11up = /Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(agent)
+
+const ie = !!(ie_upto10 || ie_11up || ie_edge)
+
+export const safari = !ie && !!nav && /Apple Computer/.test(nav.vendor)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,10 @@ export {
 export { createListInputRules, wrappingListInputRule } from './input-rule'
 export { migrateDocJSON } from './migrate'
 export { createListNodeView } from './node-view'
-export { createListPlugin } from './plugin'
+export {
+  createListPlugin,
+  createSafariInputMethodWorkaroundPlugin,
+} from './plugin'
 export { createParseDomRules } from './schema/parse-dom'
 export { createListSpec, flatListGroup } from './schema/spec'
 export {

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -1,5 +1,7 @@
 import { Schema } from 'prosemirror-model'
 import { Plugin } from 'prosemirror-state'
+import { Decoration, DecorationSet, EditorView } from 'prosemirror-view'
+import * as browser from './browser'
 import { handleListMarkerMouseDown } from './dom-events'
 import { createListNodeView } from './node-view'
 import { ListDOMSerializer } from './utils/list-serializer'
@@ -31,6 +33,50 @@ export function createListPlugin(schema: Schema): Plugin {
       nodeViews: {
         list: createListNodeView,
       },
+    },
+  })
+}
+
+/**
+ * Return a plugin as a workaround for a bug in Safari that causes the composition
+ * based IME to remove the empty HTML element with CSS `position: relative`.
+ *
+ * See also https://github.com/ProseMirror/prosemirror/issues/934
+ *
+ * @public
+ */
+export function createSafariInputMethodWorkaroundPlugin(): Plugin {
+  let view: EditorView | null = null
+  let span: HTMLSpanElement | null = null
+
+  const getSpan = (): HTMLSpanElement => {
+    if (!span) {
+      span = document.createElement('span')
+      span.className = 'prosemirror-flat-list-safari-workaround'
+    }
+    return span
+  }
+
+  const createDecorations = (): DecorationSet | null => {
+    if (view?.composing) {
+      const state = view.state
+      const selection = state.selection
+      const { $from, $to, to } = selection
+      if ($from.sameParent($to)) {
+        return DecorationSet.create(state.doc, [Decoration.widget(to, getSpan)])
+      }
+    }
+    return null
+  }
+
+  return new Plugin({
+    props: {
+      decorations: browser.safari ? createDecorations : undefined,
+    },
+
+    view: (v) => {
+      view = v
+      return {}
     },
   })
 }

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -5,10 +5,9 @@
     margin-bottom: 0;
     margin-left: 32px;
     margin-bottom: 0;
+    position: relative;
     display: list-item;
     list-style: none;
-
-    /* Note: we cannot add "position: relative;" here because of a Safari bug: https://github.com/ocavue/prosemirror-flat-list/issues/50 */
   }
 
   &.ProseMirror-selectednode {
@@ -38,7 +37,7 @@
     }
     &::before {
       position: absolute;
-      transform: translateX(-100%);
+      right: 100%;
       font-variant-numeric: tabular-nums;
       content: counter(prosemirror-flat-list-counter, decimal) '. ';
     }
@@ -47,7 +46,7 @@
   &[data-list-kind='task'] {
     & > .list-marker {
       position: absolute;
-      transform: translateX(-100%);
+      right: 100%;
       text-align: center;
       width: 1.5em;
       width: 1lh;
@@ -62,7 +61,7 @@
   &[data-list-kind='toggle'] {
     & > .list-marker {
       position: absolute;
-      transform: translateX(-100%);
+      right: 100%;
       text-align: center;
       width: 1.5em;
       width: 1lh;

--- a/packages/core/test/extension.ts
+++ b/packages/core/test/extension.ts
@@ -8,7 +8,6 @@ import {
   ProsemirrorPlugin,
 } from '@remirror/core'
 import { NodeRange } from 'prosemirror-model'
-
 import {
   alwaysTrue,
   createDedentListCommand,
@@ -17,6 +16,7 @@ import {
   createListPlugin,
   createListSpec,
   createMoveListCommand,
+  createSafariInputMethodWorkaroundPlugin,
   createSplitListCommand,
   createToggleCollapsedCommand,
   createWrapInListCommand,
@@ -55,7 +55,10 @@ export class ListExtension extends NodeExtension {
   }
 
   createExternalPlugins(): ProsemirrorPlugin[] {
-    return [createListPlugin(this.store.schema)]
+    return [
+      createListPlugin(this.store.schema),
+      createSafariInputMethodWorkaroundPlugin(),
+    ]
   }
 
   createInputRules(): InputRule[] {

--- a/packages/remirror-extension/src/extension.ts
+++ b/packages/remirror-extension/src/extension.ts
@@ -8,15 +8,15 @@ import {
   ProsemirrorPlugin,
 } from '@remirror/core'
 import { NodeRange } from '@remirror/pm/model'
-import { createListPlugin } from 'prosemirror-flat-list'
-
 import {
   alwaysTrue,
   createDedentListCommand,
   createIndentListCommand,
   createListInputRules,
+  createListPlugin,
   createListSpec,
   createMoveListCommand,
+  createSafariInputMethodWorkaroundPlugin,
   createSplitListCommand,
   createToggleCollapsedCommand,
   createWrapInListCommand,
@@ -60,7 +60,10 @@ export class ListExtension extends NodeExtension {
   }
 
   createExternalPlugins(): ProsemirrorPlugin[] {
-    return [createListPlugin(this.store.schema)]
+    return [
+      createListPlugin(this.store.schema),
+      createSafariInputMethodWorkaroundPlugin(),
+    ]
   }
 
   createInputRules(): InputRule[] {


### PR DESCRIPTION
Closes https://github.com/ocavue/prosemirror-flat-list/issues/56