### PR TITLE
fix: don't use `counter-set` for Safari

### DIFF
--- a/.changeset/tender-taxis-sparkle.md
+++ b/.changeset/tender-taxis-sparkle.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-flat-list': patch
+---
+
+Fix the custom counter for Safari

--- a/packages/core/src/schema/to-dom.ts
+++ b/packages/core/src/schema/to-dom.ts
@@ -1,5 +1,6 @@
 import { DOMOutputSpec, Node as ProsemirrorNode } from 'prosemirror-model'
 import { ListAttributes } from '../types'
+import * as browser from '../utils/browser'
 
 /** @public */
 export interface ListToDOMOptions {
@@ -110,7 +111,10 @@ export function defaultAttributesGetter(node: ProsemirrorNode) {
     'data-list-collapsable': node.childCount >= 2 ? '' : undefined,
     style:
       attrs.order != null
-        ? `counter-set: prosemirror-flat-list-counter ${attrs.order};`
+        ? // Safari (at least version <= 16.5) doesn't support `counter-set`
+          browser.safari
+          ? `counter-reset: prosemirror-flat-list-counter; counter-increment: prosemirror-flat-list-counter ${attrs.order};`
+          : `counter-set: prosemirror-flat-list-counter ${attrs.order};`
         : undefined,
   }
 


### PR DESCRIPTION
Close https://github.com/ocavue/prosemirror-flat-list/issues/102

<img width="574" alt="image" src="https://user-images.githubusercontent.com/24715727/229519599-b8aa6b76-025c-433c-82ee-fad0fe06edcf.png">

