### PR TITLE
feat: add `toggleList` and `unwrapList`

### DIFF
--- a/.changeset/tasty-moose-explode.md
+++ b/.changeset/tasty-moose-explode.md
@@ -1,5 +1,6 @@
 ---
-'prosemirror-flat-list': patch
+'prosemirror-flat-list': minor
+'remirror-extension-flat-list': minor
 ---
 
 Add two command creators: `createToggleListCommand` and `createUnwrapListCommand`.

--- a/.changeset/tasty-moose-explode.md
+++ b/.changeset/tasty-moose-explode.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-flat-list': patch
+---
+
+Add two command creators: `createToggleListCommand` and `createUnwrapListCommand`.

--- a/examples/with-remirror/editor.tsx
+++ b/examples/with-remirror/editor.tsx
@@ -98,6 +98,14 @@ function ButtonGroup() {
     })
   }
 
+  const toggleList = (kind: ListKind) => {
+    commands.toggleList({ kind })
+  }
+
+  const toggleBulletList = () => toggleList('bullet')
+  const toggleOrderedList = () => toggleList('ordered')
+  const toggleTaskList = () => toggleList('task')
+
   const moveUp = () => commands.moveList('up')
   const moveDown = () => commands.moveList('down')
 
@@ -120,6 +128,12 @@ function ButtonGroup() {
       <Button onClick={toggleChecked}>Toggle attribute checked</Button>
 
       <Button onClick={toggleCollapsed}>Toggle attribute collapsed</Button>
+
+      <Button onClick={toggleBulletList}>Toggle bullet list</Button>
+
+      <Button onClick={toggleOrderedList}>Toggle ordered list</Button>
+
+      <Button onClick={toggleTaskList}>Toggle task list</Button>
 
       <Button onClick={moveUp}>Move up</Button>
 

--- a/packages/core/src/commands/dedent-list.ts
+++ b/packages/core/src/commands/dedent-list.ts
@@ -232,7 +232,7 @@ function fixEndBoundary(range: NodeRange, tr: Transaction): void {
   moveRangeSiblings(tr, range)
 }
 
-function dedentOutOfList(tr: Transaction, range: NodeRange): boolean {
+export function dedentOutOfList(tr: Transaction, range: NodeRange): boolean {
   const { startIndex, endIndex, parent } = range
 
   const getRangeStart = mapPos(tr, range.start)

--- a/packages/core/src/commands/split-list.spec.ts
+++ b/packages/core/src/commands/split-list.spec.ts
@@ -514,6 +514,7 @@ describe('splitList', () => {
 
         1. ***
         2. <cursor>
+
       `,
     )
   })

--- a/packages/core/src/commands/split-list.ts
+++ b/packages/core/src/commands/split-list.ts
@@ -1,4 +1,3 @@
-import { isTextSelection } from '@remirror/core'
 import { chainCommands } from 'prosemirror-commands'
 import {
   Fragment,
@@ -9,7 +8,6 @@ import {
 import {
   Command,
   EditorState,
-  NodeSelection,
   Selection,
   TextSelection,
   Transaction,
@@ -21,6 +19,7 @@ import { withAutoFixList } from '../utils/auto-fix-list'
 import { createAndFill } from '../utils/create-and-fill'
 import { isBlockNodeSelection } from '../utils/is-block-node-selection'
 import { isListNode } from '../utils/is-list-node'
+import { isTextSelection } from '../utils/is-text-selection'
 
 import { dedentNodeRange } from './dedent-list'
 import { enterWithoutLift } from './enter-without-lift'
@@ -47,7 +46,7 @@ const splitBlockNodeSelectionInListCommand: Command = (state, dispatch) => {
     return false
   }
 
-  const selection = state.selection as NodeSelection
+  const selection = state.selection
   const { $to, node } = selection
   const parent = $to.parent
 

--- a/packages/core/src/commands/toggle-list.spec.ts
+++ b/packages/core/src/commands/toggle-list.spec.ts
@@ -6,7 +6,7 @@ import { createToggleListCommand } from './toggle-list'
 
 describe('toggleList', () => {
   const t = setupTestingEditor()
-  const { doc, p, orderedList } = t
+  const { doc, p, orderedList, bulletList, uncheckedTaskList } = t
   const toggleList = createToggleListCommand({ kind: 'ordered' })
 
   it('can toggle list', () => {
@@ -28,5 +28,19 @@ describe('toggleList', () => {
 
     t.applyCommand(toggleList, doc1, doc2)
     t.applyCommand(toggleList, doc2, doc1)
+  })
+
+  it('can toggle a list to another kind', () => {
+    const toggleBullet = createToggleListCommand({ kind: 'bullet' })
+    const toggleTask = createToggleListCommand({ kind: 'task' })
+
+    const doc1 = doc(p('P1<cursor>'), p('P2'))
+    const doc2 = doc(uncheckedTaskList(p('P1<cursor>')), p('P2'))
+    const doc3 = doc(bulletList(p('P1<cursor>')), p('P2'))
+
+    t.applyCommand(toggleTask, doc1, doc2)
+    t.applyCommand(toggleBullet, doc2, doc3)
+    t.applyCommand(toggleTask, doc3, doc2)
+    t.applyCommand(toggleTask, doc2, doc1)
   })
 })

--- a/packages/core/src/commands/toggle-list.spec.ts
+++ b/packages/core/src/commands/toggle-list.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it } from 'vitest'
+
+import { setupTestingEditor } from '../../test/setup-editor'
+
+import { createToggleListCommand } from './toggle-list'
+
+describe('toggleList', () => {
+  const t = setupTestingEditor()
+  const { doc, p, orderedList } = t
+  const toggleList = createToggleListCommand({ kind: 'ordered' })
+
+  it('can toggle list', () => {
+    const doc1 = doc(p('P1<cursor>'), p('P2'))
+    const doc2 = doc(orderedList(p('P1<cursor>')), p('P2'))
+
+    t.applyCommand(toggleList, doc1, doc2)
+    t.applyCommand(toggleList, doc2, doc1)
+  })
+
+  it('can toggle list with multiple selected paragraphs', () => {
+    const doc1 = doc(p('P1'), p('<start>P2'), p('P3<end>'), p('P4'))
+    const doc2 = doc(
+      p('P1'),
+      orderedList(p('<start>P2')),
+      orderedList(p('P3<end>')),
+      p('P4'),
+    )
+
+    t.applyCommand(toggleList, doc1, doc2)
+    t.applyCommand(toggleList, doc2, doc1)
+  })
+})

--- a/packages/core/src/commands/toggle-list.ts
+++ b/packages/core/src/commands/toggle-list.ts
@@ -1,5 +1,4 @@
 import { chainCommands } from 'prosemirror-commands'
-import { NodeRange } from 'prosemirror-model'
 import { Command } from 'prosemirror-state'
 
 import { ListAttributes } from '../types'
@@ -11,21 +10,20 @@ import { createWrapInListCommand } from './wrap-in-list'
  * Returns a command function that wraps the selection in a list with the given
  * type an attributes, or change the list kind if the selection is already in
  * another kind of list, or unwrap the selected list if otherwise.
- * 
+ *
  * @public
  */
 export function createToggleListCommand<
   T extends ListAttributes = ListAttributes,
 >(
   /**
-   * The list node attributes or a callback function to take the current
-   * selection block range and return list node attributes.
+   * The list node attributes to toggle.
    *
    * @public
    */
-  getAttrs: T | ((range: NodeRange) => T),
+  attrs: T,
 ): Command {
-  const unwrapList = createUnwrapListCommand()
-  const wrapInList = createWrapInListCommand(getAttrs)
+  const unwrapList = createUnwrapListCommand({ kind: attrs.kind })
+  const wrapInList = createWrapInListCommand(attrs)
   return chainCommands(unwrapList, wrapInList)
 }

--- a/packages/core/src/commands/toggle-list.ts
+++ b/packages/core/src/commands/toggle-list.ts
@@ -7,12 +7,16 @@ import { ListAttributes } from '../types'
 import { createUnwrapListCommand } from './unwrap-list'
 import { createWrapInListCommand } from './wrap-in-list'
 
+/**
+ * Returns a command function that wraps the selection in a list with the given
+ * type an attributes or unwrap the list around the selection. 
+ */
 export function createToggleListCommand<
   T extends ListAttributes = ListAttributes,
 >(
-  /** The list node attributes or a callback function to take the current
-   * selection block range and return list node attributes. If this callback
-   * function returns null, the command won't do anything.
+  /** 
+   * The list node attributes or a callback function to take the current
+   * selection block range and return list node attributes.
    *
    * @public
    */

--- a/packages/core/src/commands/toggle-list.ts
+++ b/packages/core/src/commands/toggle-list.ts
@@ -9,12 +9,12 @@ import { createWrapInListCommand } from './wrap-in-list'
 
 /**
  * Returns a command function that wraps the selection in a list with the given
- * type an attributes or unwrap the list around the selection. 
+ * type an attributes or unwrap the list around the selection.
  */
 export function createToggleListCommand<
   T extends ListAttributes = ListAttributes,
 >(
-  /** 
+  /**
    * The list node attributes or a callback function to take the current
    * selection block range and return list node attributes.
    *

--- a/packages/core/src/commands/toggle-list.ts
+++ b/packages/core/src/commands/toggle-list.ts
@@ -1,0 +1,24 @@
+import { chainCommands } from 'prosemirror-commands'
+import { NodeRange } from 'prosemirror-model'
+import { Command } from 'prosemirror-state'
+
+import { ListAttributes } from '../types'
+
+import { createUnwrapListCommand } from './unwrap-list'
+import { createWrapInListCommand } from './wrap-in-list'
+
+export function createToggleListCommand<
+  T extends ListAttributes = ListAttributes,
+>(
+  /** The list node attributes or a callback function to take the current
+   * selection block range and return list node attributes. If this callback
+   * function returns null, the command won't do anything.
+   *
+   * @public
+   */
+  getAttrs: T | ((range: NodeRange) => T),
+): Command {
+  const unwrapList = createUnwrapListCommand()
+  const wrapInList = createWrapInListCommand(getAttrs)
+  return chainCommands(unwrapList, wrapInList)
+}

--- a/packages/core/src/commands/toggle-list.ts
+++ b/packages/core/src/commands/toggle-list.ts
@@ -11,6 +11,8 @@ import { createWrapInListCommand } from './wrap-in-list'
  * Returns a command function that wraps the selection in a list with the given
  * type an attributes, or change the list kind if the selection is already in
  * another kind of list, or unwrap the selected list if otherwise.
+ * 
+ * @public
  */
 export function createToggleListCommand<
   T extends ListAttributes = ListAttributes,

--- a/packages/core/src/commands/toggle-list.ts
+++ b/packages/core/src/commands/toggle-list.ts
@@ -9,7 +9,8 @@ import { createWrapInListCommand } from './wrap-in-list'
 
 /**
  * Returns a command function that wraps the selection in a list with the given
- * type an attributes or unwrap the list around the selection.
+ * type an attributes, or change the list kind if the selection is already in
+ * another kind of list, or unwrap the selected list if otherwise.
  */
 export function createToggleListCommand<
   T extends ListAttributes = ListAttributes,

--- a/packages/core/src/commands/unwrap-list.spec.ts
+++ b/packages/core/src/commands/unwrap-list.spec.ts
@@ -1,0 +1,77 @@
+import { NodeSelection } from 'prosemirror-state'
+import { describe, expect, it } from 'vitest'
+
+import { setupTestingEditor } from '../../test/setup-editor'
+import { ListAttributes } from '../types'
+
+import { createUnwrapListCommand } from './unwrap-list'
+
+describe('unwrapList', () => {
+  const t = setupTestingEditor()
+  const { doc, p, bulletList, orderedList, checkedTaskList } = t
+  const unwrapList = createUnwrapListCommand()
+
+  it('can unwrap a list node selection', () => {
+    const doc1 = doc(bulletList(p('P1'), p('P2')))
+    const doc2 = doc(p('P1'), p('P2'))
+
+    t.add(doc1)
+    const selection = new NodeSelection(t.view.state.doc.resolve(0))
+    expect(selection.node.type.name).toEqual('list')
+    t.view.dispatch(t.view.state.tr.setSelection(selection))
+
+    expect(t.dispatchCommand(unwrapList)).toEqual(true)
+    expect(t.editor.state).toEqualRemirrorState(doc2)
+  })
+
+  it('can unwrap a list node selection in a nested list', () => {
+    const doc1 = doc(orderedList(checkedTaskList(p('P1'), p('P2'))))
+    const doc2 = doc(orderedList(p('P1'), p('P2')))
+
+    t.add(doc1)
+    const selection = new NodeSelection(t.view.state.doc.resolve(1))
+    expect(selection.node.type.name).toEqual('list')
+    expect((selection.node.attrs as ListAttributes).kind).toEqual('task')
+    t.view.dispatch(t.view.state.tr.setSelection(selection))
+
+    expect(t.dispatchCommand(unwrapList)).toEqual(true)
+    expect(t.editor.state).toEqualRemirrorState(doc2)
+  })
+
+  it('can unwrap a paragraph inside a list node', () => {
+    const doc1 = doc(orderedList(p('P<cursor>1')))
+    const doc2 = doc(p('P<cursor>1'))
+    t.applyCommand(unwrapList, doc1, doc2)
+  })
+
+  it('can unwrap all paragraphs inside a list node event only part of them are selected', () => {
+    const doc1 = doc(orderedList(p('P1'), p('P2<cursor>'), p('P3')))
+    const doc2 = doc(p('P1'), p('P2<cursor>'), p('P3'))
+    t.applyCommand(unwrapList, doc1, doc2)
+  })
+
+  it('can unwrap all paragraphs inside a list node', () => {
+    const doc1 = doc(orderedList(p('<start>P1'), p('P2'), p('P3<end>')))
+    const doc2 = doc(p('<start>P1'), p('P2'), p('P3<end>'))
+    t.applyCommand(unwrapList, doc1, doc2)
+  })
+
+  it('can unwrap multiple lists', () => {
+    const doc1 = doc(
+      p('P1'),
+      orderedList(p('P2<start>')),
+      orderedList(p('P3')),
+      orderedList(p('P4<end>'), p('P5')),
+      orderedList(p('P6')),
+    )
+    const doc2 = doc(
+      p('P1'),
+      p('P2<start>'),
+      p('P3'),
+      p('P4<end>'),
+      p('P5'),
+      orderedList(p('P6')),
+    )
+    t.applyCommand(unwrapList, doc1, doc2)
+  })
+})

--- a/packages/core/src/commands/unwrap-list.ts
+++ b/packages/core/src/commands/unwrap-list.ts
@@ -8,7 +8,7 @@ import { safeLiftFromTo } from '../utils/safe-lift'
 import { dedentOutOfList } from './dedent-list'
 
 /**
- * Returns a command function that unwraps the list around the selection. 
+ * Returns a command function that unwraps the list around the selection.
  */
 export function createUnwrapListCommand(): Command {
   const unwrapList: Command = (state, dispatch) => {

--- a/packages/core/src/commands/unwrap-list.ts
+++ b/packages/core/src/commands/unwrap-list.ts
@@ -1,0 +1,50 @@
+import { Command } from 'prosemirror-state'
+
+import { isListNode } from '../utils/is-list-node'
+import { isNodeSelection } from '../utils/is-node-selection'
+import { isListsRange } from '../utils/list-range'
+import { safeLiftFromTo } from '../utils/safe-lift'
+
+import { dedentOutOfList } from './dedent-list'
+
+export function createUnwrapListCommand(): Command {
+  const unwrapList: Command = (state, dispatch) => {
+    const selection = state.selection
+
+    if (isNodeSelection(selection) && isListNode(selection.node)) {
+      if (dispatch) {
+        const tr = state.tr
+        safeLiftFromTo(tr, tr.selection.from + 1, tr.selection.to - 1)
+        dispatch(tr.scrollIntoView())
+      }
+      return true
+    }
+
+    const range = selection.$from.blockRange(selection.$to)
+
+    if (range && isListsRange(range)) {
+      const tr = state.tr
+      if (dedentOutOfList(tr, range)) {
+        dispatch?.(tr)
+        return true
+      }
+    }
+
+    if (range && isListNode(range.parent)) {
+      if (dispatch) {
+        const tr = state.tr
+        safeLiftFromTo(
+          tr,
+          range.$from.start(range.depth),
+          range.$to.end(range.depth),
+        )
+        dispatch(tr.scrollIntoView())
+      }
+      return true
+    }
+
+    return false
+  }
+
+  return unwrapList
+}

--- a/packages/core/src/commands/unwrap-list.ts
+++ b/packages/core/src/commands/unwrap-list.ts
@@ -1,22 +1,36 @@
+import { ProsemirrorNode } from '@remirror/pm'
+import { NodeRange } from 'prosemirror-model'
 import { Command } from 'prosemirror-state'
 
+import { ListAttributes } from '../types'
 import { isListNode } from '../utils/is-list-node'
 import { isNodeSelection } from '../utils/is-node-selection'
-import { isListsRange } from '../utils/list-range'
 import { safeLiftFromTo } from '../utils/safe-lift'
 
 import { dedentOutOfList } from './dedent-list'
+
+/**
+ * @public
+ */
+export interface UnwrapListOptions {
+  /**
+   * If given, only this kind of list will be unwrap.
+   */
+  kind?: string
+}
 
 /**
  * Returns a command function that unwraps the list around the selection.
  *
  * @public
  */
-export function createUnwrapListCommand(): Command {
+export function createUnwrapListCommand(options?: UnwrapListOptions): Command {
+  const kind = options?.kind
+
   const unwrapList: Command = (state, dispatch) => {
     const selection = state.selection
 
-    if (isNodeSelection(selection) && isListNode(selection.node)) {
+    if (isNodeSelection(selection) && isTargetList(selection.node, kind)) {
       if (dispatch) {
         const tr = state.tr
         safeLiftFromTo(tr, tr.selection.from + 1, tr.selection.to - 1)
@@ -27,7 +41,7 @@ export function createUnwrapListCommand(): Command {
 
     const range = selection.$from.blockRange(selection.$to)
 
-    if (range && isListsRange(range)) {
+    if (range && isTargetListsRange(range, kind)) {
       const tr = state.tr
       if (dedentOutOfList(tr, range)) {
         dispatch?.(tr)
@@ -35,7 +49,7 @@ export function createUnwrapListCommand(): Command {
       }
     }
 
-    if (range && isListNode(range.parent)) {
+    if (range && isTargetList(range.parent, kind)) {
       if (dispatch) {
         const tr = state.tr
         safeLiftFromTo(
@@ -52,4 +66,29 @@ export function createUnwrapListCommand(): Command {
   }
 
   return unwrapList
+}
+
+function isTargetList(node: ProsemirrorNode, kind: string | undefined) {
+  if (isListNode(node)) {
+    if (kind) {
+      return (node.attrs as ListAttributes).kind === kind
+    }
+    return true
+  }
+  return false
+}
+
+function isTargetListsRange(
+  range: NodeRange,
+  kind: string | undefined,
+): boolean {
+  const { startIndex, endIndex, parent } = range
+
+  for (let i = startIndex; i < endIndex; i++) {
+    if (!isTargetList(parent.child(i), kind)) {
+      return false
+    }
+  }
+
+  return true
 }

--- a/packages/core/src/commands/unwrap-list.ts
+++ b/packages/core/src/commands/unwrap-list.ts
@@ -7,6 +7,9 @@ import { safeLiftFromTo } from '../utils/safe-lift'
 
 import { dedentOutOfList } from './dedent-list'
 
+/**
+ * Returns a command function that unwraps the list around the selection. 
+ */
 export function createUnwrapListCommand(): Command {
   const unwrapList: Command = (state, dispatch) => {
     const selection = state.selection

--- a/packages/core/src/commands/unwrap-list.ts
+++ b/packages/core/src/commands/unwrap-list.ts
@@ -9,6 +9,8 @@ import { dedentOutOfList } from './dedent-list'
 
 /**
  * Returns a command function that unwraps the list around the selection.
+ *
+ * @public
  */
 export function createUnwrapListCommand(): Command {
   const unwrapList: Command = (state, dispatch) => {

--- a/packages/core/src/commands/wrap-in-list.ts
+++ b/packages/core/src/commands/wrap-in-list.ts
@@ -16,7 +16,7 @@ import { setNodeAttributes } from '../utils/set-node-attributes'
 export function createWrapInListCommand<
   T extends ListAttributes = ListAttributes,
 >(
-  /** 
+  /**
    * The list node attributes or a callback function to take the current
    * selection block range and return list node attributes. If this callback
    * function returns null, the command won't do anything.

--- a/packages/core/src/commands/wrap-in-list.ts
+++ b/packages/core/src/commands/wrap-in-list.ts
@@ -16,7 +16,8 @@ import { setNodeAttributes } from '../utils/set-node-attributes'
 export function createWrapInListCommand<
   T extends ListAttributes = ListAttributes,
 >(
-  /** The list node attributes or a callback function to take the current
+  /** 
+   * The list node attributes or a callback function to take the current
    * selection block range and return list node attributes. If this callback
    * function returns null, the command won't do anything.
    *

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,8 @@ export {
   createToggleCollapsedCommand,
   type ToggleCollapsedOptions,
 } from './commands/toggle-collapsed'
+export { createToggleListCommand } from './commands/toggle-list'
+export { createUnwrapListCommand } from './commands/unwrap-list'
 export { createWrapInListCommand } from './commands/wrap-in-list'
 export {
   defaultListClickHandler,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,10 @@ export {
   type ToggleCollapsedOptions,
 } from './commands/toggle-collapsed'
 export { createToggleListCommand } from './commands/toggle-list'
-export { createUnwrapListCommand } from './commands/unwrap-list'
+export {
+  createUnwrapListCommand,
+  type UnwrapListOptions,
+} from './commands/unwrap-list'
 export { createWrapInListCommand } from './commands/wrap-in-list'
 export {
   defaultListClickHandler,

--- a/packages/core/src/utils/is-block-node-selection.ts
+++ b/packages/core/src/utils/is-block-node-selection.ts
@@ -1,5 +1,8 @@
 import { NodeSelection, Selection } from 'prosemirror-state'
+import { isNodeSelection } from './is-node-selection'
 
-export function isBlockNodeSelection(selection: Selection): boolean {
-  return Boolean((selection as NodeSelection).node?.type?.isBlock)
+export function isBlockNodeSelection(
+  selection: Selection,
+): selection is NodeSelection {
+  return isNodeSelection(selection) && selection.node.type.isBlock
 }

--- a/packages/core/src/utils/is-block-node-selection.ts
+++ b/packages/core/src/utils/is-block-node-selection.ts
@@ -1,4 +1,5 @@
 import { NodeSelection, Selection } from 'prosemirror-state'
+
 import { isNodeSelection } from './is-node-selection'
 
 export function isBlockNodeSelection(

--- a/packages/core/src/utils/is-node-selection.ts
+++ b/packages/core/src/utils/is-node-selection.ts
@@ -1,0 +1,7 @@
+import { NodeSelection, Selection } from 'prosemirror-state'
+
+export function isNodeSelection(
+  selection: Selection,
+): selection is NodeSelection {
+  return Boolean((selection as NodeSelection).node)
+}

--- a/packages/core/src/utils/is-text-selection.ts
+++ b/packages/core/src/utils/is-text-selection.ts
@@ -1,0 +1,5 @@
+import { TextSelection } from 'prosemirror-state'
+
+export function isTextSelection(value?: unknown): value is TextSelection {
+  return Boolean(value && value instanceof TextSelection)
+}

--- a/packages/core/src/utils/safe-lift.ts
+++ b/packages/core/src/utils/safe-lift.ts
@@ -10,3 +10,15 @@ export function safeLift(tr: Transaction, range: NodeRange): boolean {
   tr.lift(range, target)
   return true
 }
+
+export function safeLiftFromTo(
+  tr: Transaction,
+  from: number,
+  to: number,
+): boolean {
+  const $from = tr.doc.resolve(from)
+  const $to = tr.doc.resolve(to)
+  const range = $from.blockRange($to)
+  if (!range) return false
+  return safeLift(tr, range)
+}

--- a/packages/core/test/setup-editor.ts
+++ b/packages/core/test/setup-editor.ts
@@ -39,11 +39,9 @@ export function setupTestingEditor() {
     return markdownToTaggedDoc(editor, markdown)
   }
 
-const dispatchCommand = (
-  command:  Command,
-) => {
-  return command(view.state, view.dispatch.bind(view), view)
-}
+  const dispatchCommand = (command: Command) => {
+    return command(view.state, view.dispatch.bind(view), view)
+  }
 
   const applyCommand = (
     command: Command,
@@ -78,7 +76,8 @@ const dispatchCommand = (
     view,
     schema,
     add,
-    markdown,dispatchCommand,
+    markdown,
+    dispatchCommand,
     applyCommand,
     editor,
 

--- a/packages/core/test/setup-editor.ts
+++ b/packages/core/test/setup-editor.ts
@@ -39,13 +39,19 @@ export function setupTestingEditor() {
     return markdownToTaggedDoc(editor, markdown)
   }
 
+const dispatchCommand = (
+  command:  Command,
+) => {
+  return command(view.state, view.dispatch.bind(view), view)
+}
+
   const applyCommand = (
     command: Command,
     before: TaggedProsemirrorNode,
     after: TaggedProsemirrorNode | null,
   ) => {
     add(before)
-    const result = command(view.state, view.dispatch, view)
+    const result = dispatchCommand(command)
     if (!after) {
       expect(result).toBe(false)
     } else {
@@ -72,7 +78,7 @@ export function setupTestingEditor() {
     view,
     schema,
     add,
-    markdown,
+    markdown,dispatchCommand,
     applyCommand,
     editor,
 

--- a/packages/remirror-extension/src/extension.ts
+++ b/packages/remirror-extension/src/extension.ts
@@ -16,6 +16,8 @@ import {
   createMoveListCommand,
   createSplitListCommand,
   createToggleCollapsedCommand,
+  createToggleListCommand,
+  createUnwrapListCommand,
   createWrapInListCommand,
   DedentListOptions,
   IndentListOptions,
@@ -24,6 +26,7 @@ import {
   listKeymap,
   protectCollapsed,
   ToggleCollapsedOptions,
+  UnwrapListOptions,
 } from 'prosemirror-flat-list'
 
 /**
@@ -74,6 +77,10 @@ export class ListExtension extends NodeExtension {
         return convertCommand(createDedentListCommand(props))
       },
 
+      unwrapList: (options?: UnwrapListOptions) => {
+        return convertCommand(createUnwrapListCommand(options))
+      },
+
       wrapInList: (
         getAttrs:
           | ListAttributes
@@ -92,6 +99,10 @@ export class ListExtension extends NodeExtension {
 
       toggleCollapsed: (props?: ToggleCollapsedOptions) => {
         return convertCommand(createToggleCollapsedCommand(props))
+      },
+
+      toggleList: (attrs: ListAttributes) => {
+        return convertCommand(createToggleListCommand(attrs))
       },
     } as const
   }

--- a/website/pages/docs/prosemirror-flat-list/index.md
+++ b/website/pages/docs/prosemirror-flat-list/index.md
@@ -8,6 +8,7 @@
 - [ListToDOMOptions](index.md#listtodomoptions)
 - [ProsemirrorNodeJSON](index.md#prosemirrornodejson)
 - [ToggleCollapsedOptions](index.md#togglecollapsedoptions)
+- [UnwrapListOptions](index.md#unwraplistoptions)
 
 ## Interfaces
 
@@ -82,11 +83,21 @@
 | `collapsed`?    | `boolean`             | If this value exists, the command will set the `collapsed` attribute to<br />this value instead of toggle it.             |
 | `isToggleable`? | (`node`) => `boolean` | An optional function to accept a list node and return whether or not this<br />node can toggle its `collapsed` attribute. |
 
+---
+
+### UnwrapListOptions
+
+#### Properties
+
+| Property | Type     | Description                                      |
+| :------- | :------- | :----------------------------------------------- |
+| `kind`?  | `string` | If given, only this kind of list will be unwrap. |
+
 ## Functions
 
 ### createToggleListCommand()
 
-> **createToggleListCommand**\<`T`\>(`getAttrs`): [`Command`](https://prosemirror.net/docs/ref/#state.Command)
+> **createToggleListCommand**\<`T`\>(`attrs`): [`Command`](https://prosemirror.net/docs/ref/#state.Command)
 
 Returns a command function that wraps the selection in a list with the given
 type an attributes, or change the list kind if the selection is already in
@@ -100,9 +111,9 @@ another kind of list, or unwrap the selected list if otherwise.
 
 #### Parameters
 
-| Parameter  | Type                    | Description                                                                                                                     |
-| :--------- | :---------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| `getAttrs` | `T` \| (`range`) => `T` | The list node attributes or a callback function to take the current<br />selection block range and return list node attributes. |
+| Parameter | Type | Description                         |
+| :-------- | :--- | :---------------------------------- |
+| `attrs`   | `T`  | The list node attributes to toggle. |
 
 #### Returns
 
@@ -112,9 +123,15 @@ another kind of list, or unwrap the selected list if otherwise.
 
 ### createUnwrapListCommand()
 
-> **createUnwrapListCommand**(): [`Command`](https://prosemirror.net/docs/ref/#state.Command)
+> **createUnwrapListCommand**(`options`?): [`Command`](https://prosemirror.net/docs/ref/#state.Command)
 
 Returns a command function that unwraps the list around the selection.
+
+#### Parameters
+
+| Parameter  | Type                                              |
+| :--------- | :------------------------------------------------ |
+| `options`? | [`UnwrapListOptions`](index.md#unwraplistoptions) |
 
 #### Returns
 

--- a/website/pages/docs/prosemirror-flat-list/index.md
+++ b/website/pages/docs/prosemirror-flat-list/index.md
@@ -84,6 +84,44 @@
 
 ## Functions
 
+### createToggleListCommand()
+
+> **createToggleListCommand**\<`T`\>(`getAttrs`): [`Command`](https://prosemirror.net/docs/ref/#state.Command)
+
+Returns a command function that wraps the selection in a list with the given
+type an attributes, or change the list kind if the selection is already in
+another kind of list, or unwrap the selected list if otherwise.
+
+#### Type parameters
+
+| Parameter                                                 | Default                                     |
+| :-------------------------------------------------------- | :------------------------------------------ |
+| `T` _extends_ [`ListAttributes`](index.md#listattributes) | [`ListAttributes`](index.md#listattributes) |
+
+#### Parameters
+
+| Parameter  | Type                    | Description                                                                                                                     |
+| :--------- | :---------------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| `getAttrs` | `T` \| (`range`) => `T` | The list node attributes or a callback function to take the current<br />selection block range and return list node attributes. |
+
+#### Returns
+
+[`Command`](https://prosemirror.net/docs/ref/#state.Command)
+
+---
+
+### createUnwrapListCommand()
+
+> **createUnwrapListCommand**(): [`Command`](https://prosemirror.net/docs/ref/#state.Command)
+
+Returns a command function that unwraps the list around the selection.
+
+#### Returns
+
+[`Command`](https://prosemirror.net/docs/ref/#state.Command)
+
+---
+
 ### findListsRange()
 
 > **findListsRange**(`$from`, `$to` = `$from`): [`NodeRange`](https://prosemirror.net/docs/ref/#model.NodeRange) \| `null`

--- a/website/pages/docs/remirror-extension-flat-list/index.md
+++ b/website/pages/docs/remirror-extension-flat-list/index.md
@@ -62,6 +62,8 @@ NodeExtension.name
 | `readonly` `protectCollapsed` | () => `CommandFunction`\< `object` \>            |
 | `readonly` `splitList`        | () => `CommandFunction`\< `object` \>            |
 | `readonly` `toggleCollapsed`  | (`props`?) => `CommandFunction`\< `object` \>    |
+| `readonly` `toggleList`       | (`attrs`) => `CommandFunction`\< `object` \>     |
+| `readonly` `unwrapList`       | (`options`?) => `CommandFunction`\< `object` \>  |
 | `readonly` `wrapInList`       | (`getAttrs`) => `CommandFunction`\< `object` \>  |
 
 ###### Overrides


### PR DESCRIPTION
Add two new commands: `toggleList` and `unwrapList`. 

 

https://github.com/ocavue/prosemirror-flat-list/assets/24715727/f00647c9-44b6-42be-952d-815caa020603


Close https://github.com/ocavue/prosemirror-flat-list/issues/148


