### PR TITLE
fix: keep checkbox state while pasting

### DIFF
--- a/.changeset/four-bananas-fetch.md
+++ b/.changeset/four-bananas-fetch.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-flat-list': patch
+---
+
+Keep the checkbox state when pasting task lists into an empty bullet list.

--- a/packages/core/src/plugins/clipboard.spec.ts
+++ b/packages/core/src/plugins/clipboard.spec.ts
@@ -73,4 +73,38 @@ describe('Clipboard', () => {
     })
     expect(t.editor.view.state).toEqualRemirrorState(t.doc(t.p('D1')))
   })
+
+  it('can keep the checkbox state when pasting into a bullet list', () => {
+    t.add(
+      t.doc(
+        t.bulletList(t.p('Bullet 1')),
+        t.checkedTaskList(t.p('<start>Task 1')),
+        t.uncheckedTaskList(t.p('Task 2<end>')),
+        t.bulletList(t.p('Bullet 2')),
+      ),
+    )
+
+    const copied = t.editor.copied
+
+    t.add(
+      t.doc(
+        t.bulletList(t.p('Bullet 1')),
+        t.bulletList(t.p('Bullet 2')),
+        t.bulletList(t.p('<cursor>')),
+      ),
+    )
+
+    pasteContent({
+      view: t.editor.view,
+      content: copied,
+    })
+    expect(t.editor.view.state).toEqualRemirrorState(
+      t.doc(
+        t.bulletList(t.p('Bullet 1')),
+        t.bulletList(t.p('Bullet 2')),
+        t.checkedTaskList(t.p('Task 1')),
+        t.uncheckedTaskList(t.p('Task 2')),
+      ),
+    )
+  })
 })

--- a/packages/core/src/schema/node-spec.ts
+++ b/packages/core/src/schema/node-spec.ts
@@ -20,7 +20,8 @@ export function createListSpec(): NodeSpec {
   return {
     content: 'block+',
     group: `${flatListGroup} block`,
-    defining: true,
+    definingForContent: true,
+    definingAsContext: false,
     attrs: {
       kind: {
         default: 'bullet',


### PR DESCRIPTION
Before:

https://github.com/ocavue/prosemirror-flat-list/assets/24715727/0b34580d-88f0-414e-91a3-bce5ec009245

After:


https://github.com/ocavue/prosemirror-flat-list/assets/24715727/b29fda5d-0b5d-4019-a028-d2386b337729


