### PR TITLE
fix: prevent the sub-list counter from escaping in Chrome

### DIFF
--- a/.changeset/brown-shoes-dream.md
+++ b/.changeset/brown-shoes-dream.md
@@ -2,4 +2,4 @@
 'prosemirror-flat-list': patch
 ---
 
-Fix a bug where the order counter might be incorrectly affected by sub-lists in Chrome.
+Fix a bug where the ordered list counter number might be incorrectly affected by sub-lists in Chrome.

--- a/.changeset/brown-shoes-dream.md
+++ b/.changeset/brown-shoes-dream.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-flat-list': patch
+---
+
+Fix a bug where the order counter might be incorrectly affected by sub-lists on Chrome.

--- a/.changeset/brown-shoes-dream.md
+++ b/.changeset/brown-shoes-dream.md
@@ -2,4 +2,4 @@
 'prosemirror-flat-list': patch
 ---
 
-Fix a bug where the order counter might be incorrectly affected by sub-lists on Chrome.
+Fix a bug where the order counter might be incorrectly affected by sub-lists in Chrome.

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -30,6 +30,16 @@
   }
 
   &[data-list-kind='ordered'] {
+    /*
+    Ensure that the counters in children don't escape, so that the sub lists
+    won't affect the counter of the parent list.
+
+    See also https://github.com/ocavue/prosemirror-flat-list/issues/23
+    */
+    & > * {
+      contain: style;
+    }
+
     &::before {
       position: absolute;
       right: 100%;
@@ -38,7 +48,7 @@
     }
 
     /* 
-    Firefox has different CSS Counter implemetation compare to Chrome and Safari, so
+    Firefox has different CSS Counter implementation compare to Chrome and Safari, so
     we need to apply different CSS rules for Firefox.  
     https://bugzilla.mozilla.org/show_bug.cgi?id=1841791
     */


### PR DESCRIPTION
Closes https://github.com/ocavue/prosemirror-flat-list/issues/23

**Before:**

https://github.com/ocavue/prosemirror-flat-list/assets/24715727/5a06e17f-c878-4b25-88d8-e969ad99b96c




**After:**

https://github.com/ocavue/prosemirror-flat-list/assets/24715727/88dfe75a-8b03-46d6-8a46-b3d420a6132d

