### PR TITLE
fix: reset counter correctly in Firefox

### DIFF
--- a/.changeset/tiny-ladybugs-relate.md
+++ b/.changeset/tiny-ladybugs-relate.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-flat-list': patch
+---
+
+Fix some incorrect ordered list counter numbers in Firefox.

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -47,25 +47,13 @@
       content: counter(prosemirror-flat-list-counter, decimal) '. ';
     }
 
+    counter-increment: prosemirror-flat-list-counter;
+
     /* 
-    Firefox has different CSS Counter implementation compare to Chrome and Safari, so
-    we need to apply different CSS rules for Firefox.  
-    https://bugzilla.mozilla.org/show_bug.cgi?id=1841791
+    Reset the counter for the first child of the list.
     */
-
-    /* CSS rules for Firefox */
-    @supports (-moz-appearance: none) {
-      contain: style;
-      counter-increment: prosemirror-flat-list-counter;
-    }
-
-    /* CSS rules for Chrome and Safari */
-    @supports not (-moz-appearance: none) {
+    :not(&) + & {
       counter-reset: prosemirror-flat-list-counter;
-      counter-increment: prosemirror-flat-list-counter;
-      & + & {
-        counter-reset: none;
-      }
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/ocavue/prosemirror-flat-list/issues/177

**Before:**

<img width="316" alt="image" src="https://github.com/ocavue/prosemirror-flat-list/assets/24715727/210f1626-8819-4e43-b9fe-8c28e81792c1">


**After:**

<img width="287" alt="image" src="https://github.com/ocavue/prosemirror-flat-list/assets/24715727/f6cff72e-9f63-457d-a0ae-88177e7d85da">



---

Closes https://github.com/ocavue/prosemirror-flat-list/issues/175


https://github.com/ocavue/prosemirror-flat-list/assets/24715727/0907e826-3ee1-4484-bb21-71611f69b14e

---

I'm not sure why this change fixes the bug in Firefox. One possible reason is that there are two `counter-reset:` before this PR, and one would override another in some cases. After this PR, there would only one `counter-reset:` rule and no overriding in any case. 
