### PR TITLE
fix: only apply custom counter number for the first list node

### DIFF
--- a/.changeset/tender-parrots-deliver.md
+++ b/.changeset/tender-parrots-deliver.md
@@ -2,4 +2,4 @@
 'prosemirror-flat-list': patch
 ---
 
-Only apply the first ordered list node in the sequence to have a custom counter number.
+Only allow the first ordered list node in the sequence to have a custom counter number.

--- a/.changeset/tender-parrots-deliver.md
+++ b/.changeset/tender-parrots-deliver.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-flat-list': patch
+---
+
+Only apply the first ordered list node in the sequence to have a custom counter number.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Emit .d.ts files
         run: nr --filter prosemirror-flat-list build
-          
+
       - name: Lint
         run: nr lint
 

--- a/packages/core/src/schema/to-dom.ts
+++ b/packages/core/src/schema/to-dom.ts
@@ -1,7 +1,6 @@
 import { DOMOutputSpec, Node as ProsemirrorNode } from 'prosemirror-model'
 
 import { ListAttributes } from '../types'
-import * as browser from '../utils/browser'
 
 /** @public */
 export interface ListToDOMOptions {

--- a/packages/core/src/schema/to-dom.ts
+++ b/packages/core/src/schema/to-dom.ts
@@ -112,10 +112,7 @@ export function defaultAttributesGetter(node: ProsemirrorNode) {
     'data-list-collapsable': node.childCount >= 2 ? '' : undefined,
     style:
       attrs.order != null
-        ? // Safari (at least version <= 16.5) doesn't support `counter-set`
-          browser.safari
-          ? `counter-reset: prosemirror-flat-list-counter; counter-increment: prosemirror-flat-list-counter ${attrs.order};`
-          : `counter-set: prosemirror-flat-list-counter ${attrs.order};`
+        ? `--prosemirror-flat-list-order: ${attrs.order};`
         : undefined,
   }
 

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -53,7 +53,6 @@
     Reset the counter for the first list node in the sequence.
     */
     :is(&:first-child, :not(&) + &) {
-      background-color: green;
       counter-reset: prosemirror-flat-list-counter;
 
       /* 

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -50,10 +50,27 @@
     counter-increment: prosemirror-flat-list-counter;
 
     /* 
-    Reset the counter for the first child of the list.
+    Reset the counter for the first list node in the sequence.
     */
-    :not(&) + & {
+    :is(&:first-child, :not(&) + &) {
+      background-color: green;
       counter-reset: prosemirror-flat-list-counter;
+
+      /* 
+      If the first list node has a custom order number, set the counter to that value.
+      */
+      &[data-list-order] {
+        counter-set: prosemirror-flat-list-counter
+          var(--prosemirror-flat-list-order);
+
+        /* 
+        Safari (at least version <= 17.1) doesn't support `counter-set` 
+        */
+        @supports not (counter-set: prosemirror-flat-list-counter 1) {
+          counter-increment: prosemirror-flat-list-counter
+            var(--prosemirror-flat-list-order);
+        }
+      }
     }
   }
 

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -52,7 +52,8 @@
     /* 
     Reset the counter for the first list node in the sequence.
     */
-    :is(&:first-child, :not(&) + &) {
+    &:first-child,
+    :not(&) + & {
       counter-reset: prosemirror-flat-list-counter;
 
       /* 

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -60,8 +60,10 @@
       If the first list node has a custom order number, set the counter to that value.
       */
       &[data-list-order] {
-        counter-set: prosemirror-flat-list-counter
-          var(--prosemirror-flat-list-order);
+        @supports (counter-set: prosemirror-flat-list-counter 1) {
+          counter-set: prosemirror-flat-list-counter
+            var(--prosemirror-flat-list-order);
+        }
 
         /* 
         Safari (at least version <= 17.1) doesn't support `counter-set` 


### PR DESCRIPTION
`prosemirror-flat-list` allows users to force set the custom counter number by typing a number larger than one. This is useful if you don't want a list to start with `1.`. However, if the custom number exactly equals the default number, this could cause some trouble. Here is an example to show such a case:

https://github.com/ocavue/prosemirror-flat-list/assets/24715727/ea7158c5-b073-4df2-a89c-a599a08399e4

--- 

This PR improves it by only allowing a custom counter number for the first list node. 



https://github.com/ocavue/prosemirror-flat-list/assets/24715727/0835732d-ab5a-486a-99a0-c3f6cad6bf88


