### PR TITLE
test: use the shared prosekit clipboard helpers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,8 +50,8 @@
     "prosemirror-view": "^1.41.8"
   },
   "devDependencies": {
-    "@prosekit/core": "^0.12.2",
-    "@prosekit/pm": "^0.1.17",
+    "@prosekit/core": "^0.12.3",
+    "@prosekit/pm": "^0.1.18",
     "@tsdown/css": "^0.22.0",
     "@types/node": "^22.0.0",
     "@vitest/browser-playwright": "^4.1.6",

--- a/packages/core/src/plugins/clipboard.spec.ts
+++ b/packages/core/src/plugins/clipboard.spec.ts
@@ -6,7 +6,7 @@ import { setupTestingEditor } from '../../test/setup-editor'
 describe('Clipboard', () => {
   const t = setupTestingEditor()
 
-  it('can paste some deeply nested list nodes', () => {
+  it('can paste some deeply nested list nodes', async () => {
     t.add(
       t.doc(
         t.bulletList(
@@ -23,7 +23,7 @@ describe('Clipboard', () => {
       ),
     )
 
-    const copied = t.copy()
+    const copied = await t.copy()
     expect(copied.html).toMatchInlineSnapshot(
       `"<ul data-pm-slice="2 2 []"><li class="prosemirror-flat-list" data-list-kind="bullet"><p>D1</p></li><li class="prosemirror-flat-list" data-list-kind="bullet"><p>D2</p></li></ul>"`,
     )
@@ -41,7 +41,7 @@ describe('Clipboard', () => {
     )
   })
 
-  it('can paste the text from a deeply nested list', () => {
+  it('can paste the text from a deeply nested list', async () => {
     t.add(
       t.doc(
         t.bulletList(
@@ -58,7 +58,7 @@ describe('Clipboard', () => {
       ),
     )
 
-    const copied = t.copy()
+    const copied = await t.copy()
     expect(copied.html).toMatchInlineSnapshot(
       `"<p data-pm-slice="1 1 []">D1</p>"`,
     )
@@ -69,7 +69,7 @@ describe('Clipboard', () => {
     expectStateToEqual(t.editor.state, t.doc(t.p('D1')))
   })
 
-  it('can keep the checkbox state when pasting into a bullet list', () => {
+  it('can keep the checkbox state when pasting into a bullet list', async () => {
     t.add(
       t.doc(
         t.bulletList(t.p('Bullet 1')),
@@ -79,7 +79,7 @@ describe('Clipboard', () => {
       ),
     )
 
-    const copied = t.copy()
+    const copied = await t.copy()
 
     t.add(
       t.doc(
@@ -101,7 +101,7 @@ describe('Clipboard', () => {
     )
   })
 
-  it('can keep the checkbox state when pasting into a sub bullet list', () => {
+  it('can keep the checkbox state when pasting into a sub bullet list', async () => {
     t.add(
       t.doc(
         t.bulletList(t.p('Bullet 1')),
@@ -111,7 +111,7 @@ describe('Clipboard', () => {
       ),
     )
 
-    const copied = t.copy()
+    const copied = await t.copy()
 
     t.add(
       t.doc(

--- a/packages/core/test/setup-editor.ts
+++ b/packages/core/test/setup-editor.ts
@@ -1,8 +1,14 @@
 import type { MarkAction, NodeAction, NodeChild } from '@prosekit/core'
-import { createTestEditor } from '@prosekit/core/test'
+import {
+  createTestEditor,
+  pasteHTML as pasteHTMLToView,
+  readClipboardHTML,
+  readClipboardText,
+} from '@prosekit/core/test'
 import type { ProseMirrorNode } from '@prosekit/pm/model'
 import type { Command } from '@prosekit/pm/state'
 import { expect } from 'vitest'
+import { keyboard } from 'vitest-browser-commands/playwright'
 
 import type { ListAttributes } from '../src/types'
 
@@ -53,23 +59,17 @@ export function setupTestingEditor() {
     )
   }
 
-  const copy = (): { html: string; text: string } => {
-    const view = editor.view
-    const slice = view.state.selection.content()
-    const { dom, text } = view.serializeForClipboard(slice)
-    return { html: dom.innerHTML, text }
+  const copy = async (): Promise<{ html: string; text: string }> => {
+    editor.view.dom.focus()
+    await keyboard.press('ControlOrMeta+C')
+    return {
+      html: (await readClipboardHTML()) ?? '',
+      text: (await readClipboardText()) ?? '',
+    }
   }
 
   const pasteHTML = (html: string) => {
-    const view = editor.view
-    const dataTransfer = new DataTransfer()
-    dataTransfer.setData('text/html', html)
-    const event = new ClipboardEvent('paste', {
-      clipboardData: dataTransfer,
-      bubbles: true,
-      cancelable: true,
-    })
-    view.dom.dispatchEvent(event)
+    pasteHTMLToView(editor.view, html)
   }
 
   const applyCommand = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 1.3.2
       prosemirror-model:
         specifier: ^1.25.6
-        version: 1.25.6
+        version: 1.25.7
       prosemirror-schema-basic:
         specifier: ^1.2.4
         version: 1.2.4
@@ -104,7 +104,7 @@ importers:
         version: 1.3.2
       prosemirror-model:
         specifier: ^1.25.6
-        version: 1.25.6
+        version: 1.25.7
       prosemirror-schema-basic:
         specifier: ^1.2.4
         version: 1.2.4
@@ -135,7 +135,7 @@ importers:
         version: 1.5.1
       prosemirror-model:
         specifier: ^1.25.6
-        version: 1.25.6
+        version: 1.25.7
       prosemirror-safari-ime-span:
         specifier: ^1.0.2
         version: 1.0.2
@@ -150,11 +150,11 @@ importers:
         version: 1.41.8
     devDependencies:
       '@prosekit/core':
-        specifier: ^0.12.2
-        version: 0.12.2(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+        specifier: ^0.12.3
+        version: 0.12.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm':
-        specifier: ^0.1.17
-        version: 0.1.17
+        specifier: ^0.1.18
+        version: 0.1.18
       '@tsdown/css':
         specifier: ^0.22.0
         version: 0.22.0(jiti@2.7.0)(postcss@8.5.14)(tsdown@0.22.0)(yaml@2.9.0)
@@ -213,11 +213,11 @@ importers:
         specifier: ^0.39.2
         version: 0.39.2(astro@6.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(yaml@2.9.0))(typescript@6.0.3)
       '@prosekit/core':
-        specifier: ^0.12.2
-        version: 0.12.2(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+        specifier: ^0.12.3
+        version: 0.12.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       '@prosekit/pm':
-        specifier: ^0.1.17
-        version: 0.1.17
+        specifier: ^0.1.18
+        version: 0.1.18
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
@@ -1124,11 +1124,11 @@ packages:
       preact: ^10.4.0 || ^11.0.0-0
       vite: '>=2.0.0'
 
-  '@prosekit/core@0.12.2':
-    resolution: {integrity: sha512-9hYYmuF4Wd1m6d6JEbGieFystpZBSIFad3OY5eejjS6mrd+ZX6uPSuR6sQ/AjqnUJejaLeRIx4cOi+iRNTIs9g==}
+  '@prosekit/core@0.12.3':
+    resolution: {integrity: sha512-FjiGhs7s7Wqyuf8h5X9x6OnfhOu2F6Z9IvJ0Bcy4p6VRQR6WeFZGMcV5zTTr+AVETfdvmnlkYILFmCzfcWl0dA==}
 
-  '@prosekit/pm@0.1.17':
-    resolution: {integrity: sha512-cw/RR3/j02kA3zgcuOBcbWqgL+tOm2Q/OpC+RXR1cOTmb2Pz3lkGtojqzyYRU/D3Uov6wR/GZg9VAyM3pfF0Nw==}
+  '@prosekit/pm@0.1.18':
+    resolution: {integrity: sha512-K00S6TY4gIlkWo1Y53h9STePNSPZ6UroHaIiKTkJvfMnwBBUZEc7+CUpmtNMzLtUqjmVAoaCTnW6VDBJaEXqWg==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -3433,8 +3433,8 @@ packages:
   prosemirror-menu@1.3.2:
     resolution: {integrity: sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==}
 
-  prosemirror-model@1.25.6:
-    resolution: {integrity: sha512-RIm+e9BiqAaJ1mRECv3vR3C+VG8ELoTTI+47tVudGi82yLnFOx3G/p/iSPK1HmHQdKhkkrJ68NJqxh7S+FBVmQ==}
+  prosemirror-model@1.25.7:
+    resolution: {integrity: sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==}
 
   prosemirror-safari-ime-span@1.0.2:
     resolution: {integrity: sha512-QJqD8s1zE/CuK56kDsUhndh5hiHh/gFnAuPOA9ytva2s85/ZEt2tNWeALTJN48DtWghSKOmiBsvVn2OlnJ5H2w==}
@@ -3908,8 +3908,8 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-fest@5.6.0:
-    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
     engines: {node: '>=20'}
 
   typedoc-plugin-external-package-links@0.2.0:
@@ -5389,25 +5389,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@prosekit/core@0.12.2(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
+  '@prosekit/core@0.12.3(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)':
     dependencies:
       '@ocavue/utils': 1.6.0
-      '@prosekit/pm': 0.1.17
+      '@prosekit/pm': 0.1.18
       orderedmap: 2.1.1
-      prosemirror-splittable: 0.1.1(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
-      type-fest: 5.6.0
+      prosemirror-splittable: 0.1.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      type-fest: 5.7.0
     transitivePeerDependencies:
       - prosemirror-model
       - prosemirror-state
       - prosemirror-transform
 
-  '@prosekit/pm@0.1.17':
+  '@prosekit/pm@0.1.18':
     dependencies:
       prosemirror-commands: 1.7.1
       prosemirror-history: 1.5.0
       prosemirror-inputrules: 1.5.1
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
@@ -8131,7 +8131,7 @@ snapshots:
 
   prosemirror-commands@1.7.1:
     dependencies:
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
@@ -8156,7 +8156,7 @@ snapshots:
   prosemirror-gapcursor@1.4.1:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.8
 
@@ -8184,7 +8184,7 @@ snapshots:
       prosemirror-history: 1.5.0
       prosemirror-state: 1.4.4
 
-  prosemirror-model@1.25.6:
+  prosemirror-model@1.25.7:
     dependencies:
       orderedmap: 2.1.1
 
@@ -8195,33 +8195,33 @@ snapshots:
 
   prosemirror-schema-basic@1.2.4:
     dependencies:
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.7
 
   prosemirror-schema-list@1.5.1:
     dependencies:
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
-  prosemirror-splittable@0.1.1(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0):
+  prosemirror-splittable@0.1.1(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0):
     optionalDependencies:
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
   prosemirror-state@1.4.4:
     dependencies:
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.7
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
 
   prosemirror-transform@1.12.0:
     dependencies:
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.7
 
   prosemirror-view@1.41.8:
     dependencies:
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
@@ -8791,7 +8791,7 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@5.6.0:
+  type-fest@5.7.0:
     dependencies:
       tagged-tag: 1.0.0
 

--- a/website/package.json
+++ b/website/package.json
@@ -17,8 +17,8 @@
   "devDependencies": {
     "@astrojs/preact": "^5.1.3",
     "@astrojs/starlight": "^0.39.2",
-    "@prosekit/core": "^0.12.2",
-    "@prosekit/pm": "^0.1.17",
+    "@prosekit/core": "^0.12.3",
+    "@prosekit/pm": "^0.1.18",
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.3.3",
     "preact": "^10.29.2",


### PR DESCRIPTION
Verifies the unreleased clipboard test helpers (`pasteHTML`, `readClipboardHTML`, `readClipboardText`) from `@prosekit/core/test` before they ship to npm.

## What

- `setup-editor.ts`: the `copy()` and `pasteHTML()` test helpers now delegate to the shared `@prosekit/core/test` API instead of hand-rolled `serializeForClipboard` / `ClipboardEvent` code. `copy()` now performs a real `Ctrl/Cmd+C` and reads the system clipboard via `readClipboardHTML()` / `readClipboardText()`.
- `clipboard.spec.ts`: the affected tests are now `async` and `await t.copy()`.

## Result

All 132 tests pass. The copied-HTML inline snapshots are unchanged, confirming `readClipboardHTML()` returns exactly the same serialization the old helper produced.

## Temporary bits (do not merge as-is)

To consume the unreleased API, `pnpm-workspace.yaml` pins the `pkg.pr.new` snapshots and deduplicates `prosemirror-model`:

- `overrides` for `@prosekit/core` / `@prosekit/pm` -> `https://pkg.pr.new/...@c253418`
- `prosemirror-model` pinned to a single version (the snapshot pulled a second copy)
- `blockExoticSubdeps: false` to allow the snapshot URL subdependency

These should be reverted once the upstream change is published to npm. This PR exists to verify that change.