### PR TITLE
fix: inherit splittable attributes when splitting a list node

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
     "prosemirror-inputrules": "^1.5.1",
     "prosemirror-model": "^1.25.9",
     "prosemirror-safari-ime-span": "^1.0.2",
+    "prosemirror-splittable": "^1.1.0",
     "prosemirror-state": "^1.4.4",
     "prosemirror-transform": "^1.12.0",
     "prosemirror-view": "^1.41.9"

--- a/packages/core/src/commands/split-list.spec.ts
+++ b/packages/core/src/commands/split-list.spec.ts
@@ -21,7 +21,20 @@ describe('splitList', () => {
     expandedToggleList,
     checkedTaskList,
     uncheckedTaskList,
+    listWithAttrs,
   } = setupTestingEditor()
+
+  const starBulletList = listWithAttrs({ kind: 'bullet', marker: '*' })
+  const checkedStarTaskList = listWithAttrs({
+    kind: 'task',
+    marker: '*',
+    checked: true,
+  })
+  const uncheckedStarTaskList = listWithAttrs({
+    kind: 'task',
+    marker: '*',
+    checked: false,
+  })
 
   it('can split non-empty item', () => {
     applyCommand(
@@ -233,6 +246,37 @@ describe('splitList', () => {
         uncheckedTaskList(p('<a>2')),
         uncheckedTaskList(p('A3')),
       ),
+    )
+  })
+
+  it('inherits splittable attributes', () => {
+    // At the end of an item
+    applyCommand(
+      enterCommand,
+      doc(starBulletList(p('A1<a>'))),
+      doc(starBulletList(p('A1')), starBulletList(p('<a>'))),
+    )
+
+    // In the middle of an item
+    applyCommand(
+      enterCommand,
+      doc(starBulletList(p('A<a>1'))),
+      doc(starBulletList(p('A')), starBulletList(p('<a>1'))),
+    )
+
+    // At the start of an item
+    applyCommand(
+      enterCommand,
+      doc(starBulletList(p('<a>A1'))),
+      doc(starBulletList(p('')), starBulletList(p('<a>A1'))),
+    )
+  })
+
+  it('resets non-splittable attributes while inheriting splittable ones', () => {
+    applyCommand(
+      enterCommand,
+      doc(checkedStarTaskList(p('A1<a>'))),
+      doc(checkedStarTaskList(p('A1')), uncheckedStarTaskList(p('<a>'))),
     )
   })
 

--- a/packages/core/src/commands/split-list.ts
+++ b/packages/core/src/commands/split-list.ts
@@ -38,12 +38,9 @@ export function createSplitListCommand(): Command {
 }
 
 function deriveListAttributes(listNode: ProsemirrorNode): ListAttributes {
-  // The new list node only inherits `kind` and the attributes marked as
-  // `splittable`; per-item state (for example `checked`) resets.
-  return {
-    kind: (listNode.attrs as ListAttributes).kind,
-    ...inheritSplittableAttrs(listNode, listNode.type),
-  }
+  // The new list node only inherits the attributes marked as `splittable`
+  // (`kind` by default); per-item state (for example `checked`) resets.
+  return inheritSplittableAttrs(listNode, listNode.type) ?? {}
 }
 
 const splitBlockNodeSelectionInListCommand: Command = (state, dispatch) => {

--- a/packages/core/src/commands/split-list.ts
+++ b/packages/core/src/commands/split-list.ts
@@ -5,6 +5,7 @@ import {
   type Node as ProsemirrorNode,
   Slice,
 } from 'prosemirror-model'
+import { inheritSplittableAttrs } from 'prosemirror-splittable'
 import {
   type Command,
   type EditorState,
@@ -37,17 +38,12 @@ export function createSplitListCommand(): Command {
 }
 
 function deriveListAttributes(listNode: ProsemirrorNode): ListAttributes {
-  // The new list node only inherits `kind` and the attributes whose spec is
-  // marked as `splittable`; per-item state (for example `checked`) resets.
-  const derived: Record<string, unknown> = {
+  // The new list node only inherits `kind` and the attributes marked as
+  // `splittable`; per-item state (for example `checked`) resets.
+  return {
     kind: (listNode.attrs as ListAttributes).kind,
+    ...inheritSplittableAttrs(listNode, listNode.type),
   }
-  for (const [name, spec] of Object.entries(listNode.type.spec.attrs ?? {})) {
-    if (spec.splittable) {
-      derived[name] = listNode.attrs[name]
-    }
-  }
-  return derived
 }
 
 const splitBlockNodeSelectionInListCommand: Command = (state, dispatch) => {

--- a/packages/core/src/commands/split-list.ts
+++ b/packages/core/src/commands/split-list.ts
@@ -37,8 +37,17 @@ export function createSplitListCommand(): Command {
 }
 
 function deriveListAttributes(listNode: ProsemirrorNode): ListAttributes {
-  // For the new list node, we don't want to inherit any list attribute (For example: `checked`) other than `kind`
-  return { kind: (listNode.attrs as ListAttributes).kind }
+  // The new list node only inherits `kind` and the attributes whose spec is
+  // marked as `splittable`; per-item state (for example `checked`) resets.
+  const derived: Record<string, unknown> = {
+    kind: (listNode.attrs as ListAttributes).kind,
+  }
+  for (const [name, spec] of Object.entries(listNode.type.spec.attrs ?? {})) {
+    if (spec.splittable) {
+      derived[name] = listNode.attrs[name]
+    }
+  }
+  return derived
 }
 
 const splitBlockNodeSelectionInListCommand: Command = (state, dispatch) => {

--- a/packages/core/src/schema/node-spec.ts
+++ b/packages/core/src/schema/node-spec.ts
@@ -25,6 +25,7 @@ export function createListSpec(): NodeSpec {
     attrs: {
       kind: {
         default: 'bullet',
+        splittable: true,
       },
       order: {
         default: null,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,17 +1,5 @@
 import type { Attrs, Node } from 'prosemirror-model'
 
-declare module 'prosemirror-model' {
-  interface AttributeSpec {
-    /**
-     * When `true`, a new list node created by splitting an existing one (e.g.
-     * by pressing `Enter`) inherits this attribute from the node being split.
-     * This follows the same convention as the `prosemirror-splittable`
-     * package.
-     */
-    splittable?: boolean
-  }
-}
-
 /**
  * All default list node kinds.
  *

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,17 @@
 import type { Attrs, Node } from 'prosemirror-model'
 
+declare module 'prosemirror-model' {
+  interface AttributeSpec {
+    /**
+     * When `true`, a new list node created by splitting an existing one (e.g.
+     * by pressing `Enter`) inherits this attribute from the node being split.
+     * This follows the same convention as the `prosemirror-splittable`
+     * package.
+     */
+    splittable?: boolean
+  }
+}
+
 /**
  * All default list node kinds.
  *

--- a/packages/core/test/extension.ts
+++ b/packages/core/test/extension.ts
@@ -4,6 +4,7 @@ import {
   defineBaseCommands,
   defineBaseKeymap,
   defineKeymap,
+  defineNodeAttr,
   defineNodeSpec,
   definePlugin,
   Priority,
@@ -23,8 +24,15 @@ import {
 } from '../src/index'
 import type { ListAttributes } from '../src/types'
 
+// Mirrors a schema consumer extending the list node with a custom attribute
+// marked `splittable`, e.g. ProseKit's `defineNodeAttr({ splittable: true })`.
+export type TestListAttributes = ListAttributes & { marker?: string | null }
+
 type ListSpecExtension = Extension<{
   Nodes: { list: ListAttributes }
+}>
+type ListMarkerExtension = Extension<{
+  Nodes: { list: { marker?: string | null } }
 }>
 
 type DocExtension = Extension<{ Nodes: { doc: Record<string, never> } }>
@@ -49,6 +57,7 @@ type ListTestExtension = Union<
     HeadingExtension,
     HorizontalRuleExtension,
     ListSpecExtension,
+    ListMarkerExtension,
     BaseCommandsExtension,
   ]
 >
@@ -114,6 +123,15 @@ function defineListSpec(): ListSpecExtension {
   })
 }
 
+function defineListMarkerAttr(): ListMarkerExtension {
+  return defineNodeAttr<'list', 'marker', string | null>({
+    type: 'list',
+    attr: 'marker',
+    default: null,
+    splittable: true,
+  })
+}
+
 function defineListPlugins() {
   return definePlugin((ctx) => createListPlugins({ schema: ctx.schema }))
 }
@@ -135,6 +153,7 @@ export function defineListTestExtension(): ListTestExtension {
     defineHeading(),
     defineHorizontalRule(),
     defineListSpec(),
+    defineListMarkerAttr(),
     defineListPlugins(),
     defineListInputRules(),
     defineListKeymap(),

--- a/packages/core/test/extension.ts
+++ b/packages/core/test/extension.ts
@@ -25,7 +25,7 @@ import {
 import type { ListAttributes } from '../src/types'
 
 // Mirrors a schema consumer extending the list node with a custom attribute
-// marked `splittable`, e.g. ProseKit's `defineNodeAttr({ splittable: true })`.
+// marked `splittable`.
 export type TestListAttributes = ListAttributes & { marker?: string | null }
 
 type ListSpecExtension = Extension<{

--- a/packages/core/test/setup-editor.ts
+++ b/packages/core/test/setup-editor.ts
@@ -10,9 +10,7 @@ import type { Command } from '@prosekit/pm/state'
 import { expect } from 'vitest'
 import { keyboard } from 'vitest-browser-commands/playwright'
 
-import type { ListAttributes } from '../src/types'
-
-import { defineListTestExtension } from './extension'
+import { defineListTestExtension, type TestListAttributes } from './extension'
 import { expectStateToEqual, markdownToTaggedDoc } from './markdown'
 
 export function setupTestingEditor() {
@@ -28,7 +26,7 @@ export function setupTestingEditor() {
   const n = editor.nodes
   const m = editor.marks
 
-  const listWithAttrs = (attrs: ListAttributes) => {
+  const listWithAttrs = (attrs: TestListAttributes) => {
     return (...children: NodeChild[]) => n.list(attrs, ...children)
   }
 
@@ -109,6 +107,7 @@ export function setupTestingEditor() {
 
     n,
     m,
+    listWithAttrs,
 
     doc,
     p,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       prosemirror-safari-ime-span:
         specifier: ^1.0.2
         version: 1.0.2
+      prosemirror-splittable:
+        specifier: ^1.1.0
+        version: 1.1.0(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       prosemirror-state:
         specifier: ^1.4.4
         version: 1.4.4
@@ -3630,8 +3633,8 @@ packages:
   prosemirror-schema-list@1.5.1:
     resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
 
-  prosemirror-splittable@1.0.0:
-    resolution: {integrity: sha512-ItHOL57msNnu6G5IBAvZDglPrlBAI3404vhe2yVWW73jSAKCH76bh5TzMA6hYWi4vB+Y6popf+kxSXrMDWye+w==}
+  prosemirror-splittable@1.1.0:
+    resolution: {integrity: sha512-UOdkczz10n/I2S4cmM/DUvFlKILDqOiFKDsYZy6Elx4TublHhTY99uzXMDK2zQO9oQqmmhEPMa44+tNxD/eAwA==}
     peerDependencies:
       prosemirror-model: ^1.21.0
       prosemirror-state: ^1.4.3
@@ -5680,7 +5683,7 @@ snapshots:
       '@ocavue/utils': 1.7.0
       '@prosekit/pm': 0.1.19-beta.1
       orderedmap: 2.1.1
-      prosemirror-splittable: 1.0.0(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
+      prosemirror-splittable: 1.1.0(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)
       type-fest: 5.7.0
     transitivePeerDependencies:
       - prosemirror-model
@@ -8582,7 +8585,7 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
-  prosemirror-splittable@1.0.0(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0):
+  prosemirror-splittable@1.1.0(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0):
     optionalDependencies:
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,4 @@ allowBuilds:
   sharp: false
 minimumReleaseAgeExclude:
   - starlight-theme-nova@0.12.1
+  - prosemirror-splittable@1.1.0


### PR DESCRIPTION
Splitting a list item with Enter derived the new item's attributes from `kind` alone, dropping any custom attribute a schema consumer added to the list node. The list spec now marks `kind` as `splittable: true`, and `deriveListAttributes` simply returns `inheritSplittableAttrs(listNode, listNode.type)` from prosemirror-splittable, so a consumer attribute marked `splittable` (for example a `marker`) survives the split the same way `kind` does. Per-item state (`checked`, `collapsed`, `order`) is not marked and still resets.