### PR TITLE
fix: skip `protectCollapsed` on an explicit select-all

### DIFF
--- a/.changeset/shiny-pandas-repeat.md
+++ b/.changeset/shiny-pandas-repeat.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-flat-list': patch
+---
+
+`protectCollapsed` no longer blocks deletion when the whole document is selected with an `AllSelection`.

--- a/packages/core/src/commands/protect-collapsed.spec.ts
+++ b/packages/core/src/commands/protect-collapsed.spec.ts
@@ -1,12 +1,27 @@
-import { describe, it } from 'vitest'
+import { AllSelection } from 'prosemirror-state'
+import { describe, expect, it } from 'vitest'
 import { keyboard } from 'vitest-browser-commands/playwright'
 
 import { expectStateToEqual } from '../../test/markdown'
 import { setupTestingEditor } from '../../test/setup-editor'
 
+import { protectCollapsed } from './protect-collapsed'
+
 describe('protectCollapsed', () => {
-  const { add, doc, p, editor, collapsedToggleList, expandedToggleList } =
-    setupTestingEditor()
+  const {
+    add,
+    doc,
+    p,
+    editor,
+    view,
+    dispatchCommand,
+    collapsedToggleList,
+    expandedToggleList,
+  } = setupTestingEditor()
+
+  const selectAll = () => {
+    view.dispatch(view.state.tr.setSelection(new AllSelection(view.state.doc)))
+  }
 
   it('can skip collapsed content', async () => {
     add(
@@ -39,5 +54,39 @@ describe('protectCollapsed', () => {
         ),
       ),
     )
+  })
+
+  it('does not protect an explicit select-all', () => {
+    add(
+      doc(
+        p('above'),
+        collapsedToggleList(
+          //
+          p('123'),
+          p('456'),
+        ),
+        p('below'),
+      ),
+    )
+    selectAll()
+    expect(dispatchCommand(protectCollapsed)).toBe(false)
+    expect(view.state.doc.child(1).attrs['collapsed']).toBe(true)
+  })
+
+  it('deletes collapsed content on Backspace after an explicit select-all', async () => {
+    add(
+      doc(
+        p('above'),
+        collapsedToggleList(
+          //
+          p('123'),
+          p('456'),
+        ),
+        p('below'),
+      ),
+    )
+    selectAll()
+    await keyboard.press('Backspace')
+    expectStateToEqual(editor.state, doc(p()))
   })
 })

--- a/packages/core/src/commands/protect-collapsed.ts
+++ b/packages/core/src/commands/protect-collapsed.ts
@@ -1,4 +1,4 @@
-import type { Command } from 'prosemirror-state'
+import { AllSelection, type Command } from 'prosemirror-state'
 
 import { isCollapsedListNode } from '../utils/is-collapsed-list-node'
 
@@ -13,10 +13,17 @@ import { isCollapsedListNode } from '../utils/is-collapsed-list-node'
  * instead. Therefore the user can clearly know what content he is trying to
  * delete.
  *
+ * An explicit select-all (an `AllSelection`) is not protected: it covers the
+ * whole document, hidden content included, so deleting it is intentional.
+ *
  * @public @group Commands
  *
  */
 export const protectCollapsed: Command = (state, dispatch): boolean => {
+  if (state.selection instanceof AllSelection) {
+    return false
+  }
+
   const tr = state.tr
   let found = false
   const { from, to } = state.selection

--- a/packages/core/src/commands/protect-collapsed.ts
+++ b/packages/core/src/commands/protect-collapsed.ts
@@ -20,7 +20,7 @@ import { isCollapsedListNode } from '../utils/is-collapsed-list-node'
  *
  */
 export const protectCollapsed: Command = (state, dispatch): boolean => {
-  const {selection, doc} = state
+  const { selection, doc } = state
   if (selection instanceof AllSelection) {
     return false
   }

--- a/packages/core/src/commands/protect-collapsed.ts
+++ b/packages/core/src/commands/protect-collapsed.ts
@@ -20,15 +20,16 @@ import { isCollapsedListNode } from '../utils/is-collapsed-list-node'
  *
  */
 export const protectCollapsed: Command = (state, dispatch): boolean => {
-  if (state.selection instanceof AllSelection) {
+  const {selection, doc} = state
+  if (selection instanceof AllSelection) {
     return false
   }
 
   const tr = state.tr
   let found = false
-  const { from, to } = state.selection
+  const { from, to } = selection
 
-  state.doc.nodesBetween(from, to, (node, pos, parent, index) => {
+  doc.nodesBetween(from, to, (node, pos, parent, index) => {
     if (found && !dispatch) {
       return false
     }
@@ -38,7 +39,7 @@ export const protectCollapsed: Command = (state, dispatch): boolean => {
         return false
       }
 
-      const $pos = state.doc.resolve(pos)
+      const $pos = doc.resolve(pos)
       tr.setNodeAttribute($pos.before($pos.depth), 'collapsed', false)
     }
   })

--- a/website/src/content/docs/reference/index.md
+++ b/website/src/content/docs/reference/index.md
@@ -340,6 +340,9 @@ In such case, we will stop the delete action and expand the collapsed items
 instead. Therefore the user can clearly know what content he is trying to
 delete.
 
+An explicit select-all (an `AllSelection`) is not protected: it covers the
+whole document, hidden content included, so deleting it is intentional.
+
 </dd>
 
 </dl>


### PR DESCRIPTION
With the whole document selected via an `AllSelection`, the first Backspace/Delete now deletes the content instead of only expanding collapsed items, since an explicit select-all covers hidden content intentionally.